### PR TITLE
add stylelint, grunt-yamllint to the list of dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,17 @@ Also this module include tasks for checking your code. For that you need install
 cd MI_MODULE_PATH && npm install 
 ```
 
-Run the grunt
+Run the `test` npm script
 ```
-./node_modules/grunt/bin/grunt
+npm test
 ```
 
-Includes configuration of code and style used in MagicMirror core. Also to test these things in travis, previously you need active your repository in Travis.
+Current Tests:
+- [ESLint](http://eslint.org/) for linting the javascript
+- [stylelint](https://stylelint.io/) for linting the CSS with [stylelint-config-standard](https://github.com/stylelint/stylelint-config-standard) as its base
+- [jsonlint](https://github.com/zaach/jsonlint) for linting the translation files
+- [markdownlint](https://github.com/DavidAnson/markdownlint) for checking the markdown files (`README.md`, `CHANGELOG.md`, `LICENSE.txt`)
+- [js-yaml](https://github.com/nodeca/js-yaml) to lint the `.travis.yml` (run through [grunt-yamllint](https://github.com/geedew/grunt-yamllint))
 
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.1.0",
   "description": "Module Base template for create new modules for MagicMirror",
   "main": "MagicMirror-Module-Template.js",
+  "scripts": {
+    "test": "./node_modules/grunt/bin/grunt"
+  },
   "author": "Rodrigo Ramírez Norambuena",
   "license": "MIT",
   "devDependencies": {
@@ -11,7 +14,7 @@
     "grunt-jsonlint": "latest",
     "grunt-markdownlint": "^1.0.13",
     "grunt-stylelint": "latest",
-    "grunt-yamllint": "latest",
+    "grunt-yamllint": "^0.3.0",
     "stylelint": "^7.10.1",
     "stylelint-config-standard": "latest",
     "time-grunt": "latest"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "grunt-markdownlint": "^1.0.13",
     "grunt-stylelint": "latest",
     "grunt-yamllint": "latest",
+    "stylelint": "^7.10.1",
     "stylelint-config-standard": "latest",
     "time-grunt": "latest"
   }


### PR DESCRIPTION
Just started from scratch and after running `npm install` is where this issue came to light.

Running `./node_modules/grunt/bin/grunt` gave an error saying `Warning: Cannot find module 'stylelint' Use --force to continue.` when attempting the stylelint task. After installing styleling with npm, the issue resolved itself. I ran npm install with the `save-dev` flag to prevent this from happening in the future.

Running the tests without `grunt-yamllint` fails but gives no errors that it was not run. I also added it to the dev dependencies and updated the docs with a little bit more info describing exactly what was being run.