### PR TITLE
added getStyles:function() to load .css file

### DIFF
--- a/MagicMirror-Module-Template.js
+++ b/MagicMirror-Module-Template.js
@@ -120,6 +120,12 @@ Module.register("{{MODULE_NAME}}", {
 		return [];
 	},
 
+	getStyles: function () {
+		return [
+			'"{{MODULE_NAME}}.css',
+		];
+	},
+
 	// Load translations files
 	getTranslations: function() {
 		//FIXME: This can be load a one file javascript definition


### PR DESCRIPTION
 getStyles:function() was missing in MagicMirror-Module-Template.js