### PR TITLE
adding '' for -i param so that sed works on mac

### DIFF
--- a/create_module.sh
+++ b/create_module.sh
@@ -132,11 +132,11 @@ rm -frv $DIRECTORY_DST/templates > /dev/null
 rm $DIRECTORY_DST/LICENSE          # Module-Template-License
 rm $DIRECTORY_DST/create_module.sh # module creation script
 
-sed -i s/\{\{MODULE_NAME\}\}/$MODULE_NAME/g $DIRECTORY_DST/*.*
-sed -i s/\{\{AUTHOR_NAME\}\}/"$AUTHOR_NAME"/g $DIRECTORY_DST/*.*
-sed -i s/\{\{LICENSE\}\}/$LICENSE/g $DIRECTORY_DST/*.*
-sed -i s/\{\{YEAR\}\}/$YEAR/g $DIRECTORY_DST/*.*
-sed -i s/\{\{DESCRIPTION\}\}/"$DESCRIPTION"/g $DIRECTORY_DST/*.*
+sed -i '' s/\{\{MODULE_NAME\}\}/$MODULE_NAME/g $DIRECTORY_DST/*.*
+sed -i '' s/\{\{AUTHOR_NAME\}\}/"$AUTHOR_NAME"/g $DIRECTORY_DST/*.*
+sed -i '' s/\{\{LICENSE\}\}/$LICENSE/g $DIRECTORY_DST/*.*
+sed -i '' s/\{\{YEAR\}\}/$YEAR/g $DIRECTORY_DST/*.*
+sed -i '' s/\{\{DESCRIPTION\}\}/"$DESCRIPTION"/g $DIRECTORY_DST/*.*
 
 
 cd $DIRECTORY_DST


### PR DESCRIPTION
This pull request fixes the create_module.sh script for running on a Mac.  I haven't tested on any other environment, so would need to be ran on linux etc to make sure sed behaves the same on other environments.  Fixes issue #3 