### PR TITLE
remove "main" field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "MagicMirror-Module-Template",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Module Base template for create new modules for MagicMirror",
-  "main": "MagicMirror-Module-Template.js",
   "scripts": {
     "test": "./node_modules/grunt/bin/grunt"
   },


### PR DESCRIPTION
hey @roramirez afaik, MMM doesn't actually do anything with the `name` or `main` fields in `package.json` (right @michmich?)

and i think it's caused confusion for module authors who try to name their packages one thing and name their main .js file something else, and can't get things to load (i submitted PRs against two modules in the last few days where i had to fix this)

this would likely clear up some of the confusion