### PR TITLE
Update version of stylelint

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "grunt-markdownlint": "^1.0.13",
     "grunt-stylelint": "latest",
     "grunt-yamllint": "^0.3.0",
-    "stylelint": "^7.10.1",
+    "stylelint": "^8.3.0",
     "stylelint-config-standard": "latest",
     "time-grunt": "latest"
   }


### PR DESCRIPTION
The Gruntfile runs stylelint, which errors with "font-family-no-missing-generic-family-keyword" undefined.  This rule was added in styleline 8.3.0, and our package.json here is earlier than that.  Updating it to force a version that works.

Error running npm test:

```
Running "stylelint:simple" (stylelint) task
Warning: Running stylelint failed
Error: Undefined rule font-family-no-missing-generic-family-keyword
  at module.exports (/Users/ralberth/MagicMirror/modules/MMM-MinecraftStatus/node_modules/stylelint/lib/utils/configurationError.js:8:27)
  at Object.keys.forEach.ruleName (/Users/ralberth/MagicMirror/modules/MMM-MinecraftStatus/node_modules/stylelint/lib/augmentConfig.js:279:13)
  at Array.forEach (<anonymous>:null:null)
  at normalizeAllRuleSettings (/Users/ralberth/MagicMirror/modules/MMM-MinecraftStatus/node_modules/stylelint/lib/augmentConfig.js:275:29)
  at augmentConfigBasic.then.then.then.then.augmentedConfig (/Users/ralberth/MagicMirror/modules/MMM-MinecraftStatus/node_modules/stylelint/lib/augmentConfig.js:84:12)
  at <anonymous>:null:null
 Use --force to continue.
```

See https://github.com/stylelint/stylelint/issues/3042 for description.