### PR TITLE
making sed work with both unix and mac os x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
- - "7"
- - "6"
- - "5.1"
+ - "12"
+ - "10"
+ - "8"
 before_script:
  - npm install grunt-cli -g
 script:

--- a/create_module.sh
+++ b/create_module.sh
@@ -132,11 +132,20 @@ rm -frv $DIRECTORY_DST/templates > /dev/null
 rm $DIRECTORY_DST/LICENSE          # Module-Template-License
 rm $DIRECTORY_DST/create_module.sh # module creation script
 
-sed -i s/\{\{MODULE_NAME\}\}/$MODULE_NAME/g $DIRECTORY_DST/*.*
-sed -i s/\{\{AUTHOR_NAME\}\}/"$AUTHOR_NAME"/g $DIRECTORY_DST/*.*
-sed -i s/\{\{LICENSE\}\}/$LICENSE/g $DIRECTORY_DST/*.*
-sed -i s/\{\{YEAR\}\}/$YEAR/g $DIRECTORY_DST/*.*
-sed -i s/\{\{DESCRIPTION\}\}/"$DESCRIPTION"/g $DIRECTORY_DST/*.*
+# Based on https://stackoverflow.com/a/51060063
+# Default case for Linux sed, just use "-i"
+sedi=(-i)
+case "$(uname)" in
+  # For macOS, use two parameters
+  Darwin*) sedi=(-i "")
+esac
+
+# Expand the parameters in the actual call to "sed"
+sed "${sedi[@]}" -e s/\{\{MODULE_NAME\}\}/$MODULE_NAME/g $DIRECTORY_DST/*.*
+sed "${sedi[@]}" -e s/\{\{AUTHOR_NAME\}\}/"$AUTHOR_NAME"/g $DIRECTORY_DST/*.*
+sed "${sedi[@]}" -e s/\{\{LICENSE\}\}/$LICENSE/g $DIRECTORY_DST/*.*
+sed "${sedi[@]}" -e s/\{\{YEAR\}\}/$YEAR/g $DIRECTORY_DST/*.*
+sed "${sedi[@]}" -e s/\{\{DESCRIPTION\}\}/"$DESCRIPTION"/g $DIRECTORY_DST/*.*
 
 
 cd $DIRECTORY_DST

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "grunt-markdownlint": "^1.0.13",
     "grunt-stylelint": "latest",
     "grunt-yamllint": "^0.3.0",
-    "stylelint": "^7.10.1",
+    "stylelint": "^8.3.0",
     "stylelint-config-standard": "latest",
     "time-grunt": "latest"
   }

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "grunt": "latest",
     "grunt-eslint": "latest",
     "grunt-jsonlint": "latest",
-    "grunt-markdownlint": "^1.0.13",
+    "grunt-markdownlint": "latest",
     "grunt-stylelint": "latest",
-    "grunt-yamllint": "^0.3.0",
-    "stylelint": "^8.3.0",
+    "grunt-yamllint": "latest",
+    "stylelint": "latest",
     "stylelint-config-standard": "latest",
     "time-grunt": "latest"
   }


### PR DESCRIPTION
Workaround for `sed` differences between GNU and OS X versions.

Hey Rodrigo, I know this repo is somewhat old. I grabbed it to make another MMM module and found that issue from a while ago. Here is my proposed solution based on https://stackoverflow.com/a/51060063

fixes #3 


